### PR TITLE
feat(solutions): add Qovery Kubernetes Management Platform

### DIFF
--- a/data/solutions.yaml
+++ b/data/solutions.yaml
@@ -1536,7 +1536,7 @@ solutions:
     production_ready: true
   - name: Qovery
     category: ManagementPlatform
-    url: https://www.qovery.com/product/provision
+    url: https://github.com/Qovery/engine
     icon_url: https://avatars.githubusercontent.com/u/55960755?s=200&v=4
     publisher: Qovery
     description: >-
@@ -1545,24 +1545,16 @@ solutions:
       with automated upgrades, fleet dashboard, and AI-assisted operations
     license: GPL-3.0-only
     open_source: true
-    cloud_providers:
-      - aws
-      - gcp
-      - azure
-      - scaleway
     tags:
       - multi-cluster
       - enterprise
       - multi-cloud
     production_ready: true
+    stars: 2500
     references:
       - title: Qovery Provision – Kubernetes Management Platform
         language: en
         url: https://www.qovery.com/product/provision
-        type: documentation
-      - title: Qovery Engine – GitHub Repository
-        language: en
-        url: https://github.com/Qovery/engine
         type: documentation
   - name: Rafay
     category: ManagementPlatform

--- a/data/solutions.yaml
+++ b/data/solutions.yaml
@@ -1534,6 +1534,36 @@ solutions:
       - enterprise
       - gui
     production_ready: true
+  - name: Qovery
+    category: ManagementPlatform
+    url: https://www.qovery.com/product/provision
+    icon_url: https://avatars.githubusercontent.com/u/55960755?s=200&v=4
+    publisher: Qovery
+    description: >-
+      Kubernetes management platform for provisioning and operating clusters
+      across AWS EKS, GCP GKE, Azure AKS, Scaleway, and bring-your-own clusters
+      with automated upgrades, fleet dashboard, and AI-assisted operations
+    license: GPL-3.0-only
+    open_source: true
+    cloud_providers:
+      - aws
+      - gcp
+      - azure
+      - scaleway
+    tags:
+      - multi-cluster
+      - enterprise
+      - multi-cloud
+    production_ready: true
+    references:
+      - title: Qovery Provision – Kubernetes Management Platform
+        language: en
+        url: https://www.qovery.com/product/provision
+        type: documentation
+      - title: Qovery Engine – GitHub Repository
+        language: en
+        url: https://github.com/Qovery/engine
+        type: documentation
   - name: Rafay
     category: ManagementPlatform
     url: https://rafay.co/


### PR DESCRIPTION
## Add Qovery

[Qovery](https://www.qovery.com/product/provision) is a Kubernetes management platform that provisions and operates clusters across multiple cloud providers. 🇫🇷 Made in France.

### Why it belongs here

**Open-source engine**
The deployment engine powering Qovery — [Qovery/engine](https://github.com/Qovery/engine) — is open source (GPL-3.0), written in Rust. It abstracts cloud deployments on top of Kubernetes, Terraform, Helm, and Docker.

**Multi-cloud / multi-cluster**
Qovery provisions and manages clusters across AWS EKS, GCP GKE, Azure AKS, Scaleway Kapsule, and bring-your-own clusters (EKS Anywhere, OpenShift, K3s, bare metal). A unified fleet dashboard gives visibility across all clusters, versions, and workloads.

**Production and development use cases**
- Production: orchestrated canary-style upgrades, HA node groups, platform add-ons (ingress, cert-manager, external-dns, monitoring)
- Development: remote dev environments with pre-configured setups, ephemeral environments to eliminate staging bottlenecks, and sandboxed runtime environments for AI agent workloads

**ClickOps or GitOps**
Qovery supports both workflows:
- **ClickOps**: self-service web console for teams who want to deploy without writing infrastructure code
- **GitOps**: full CI/CD pipeline integration and a [Terraform provider](https://registry.terraform.io/providers/Qovery/qovery/latest) for teams who prefer infrastructure-as-code and declarative configuration

### Entry details

```yaml
- name: Qovery
  category: ManagementPlatform
  url: https://github.com/Qovery/engine
  license: GPL-3.0
  open_source: true
  cloud_providers: [aws, gcp, azure, scaleway]
  tags: [multi-cluster, enterprise, multi-cloud]
  production_ready: true
```